### PR TITLE
Add strata_configure_model MCP tool (v0.12)

### DIFF
--- a/src/tools/config.rs
+++ b/src/tools/config.rs
@@ -1,0 +1,53 @@
+//! Model configuration tools.
+//!
+//! Tools: strata_configure_model
+
+use serde_json::{Map, Value as JsonValue};
+use stratadb::Command;
+
+use crate::convert::{get_optional_string, get_optional_u64, get_string_arg};
+use crate::error::{McpError, Result};
+use crate::schema;
+use crate::session::McpSession;
+use crate::tools::ToolDef;
+
+/// Get all configuration tool definitions.
+pub fn tools() -> Vec<ToolDef> {
+    vec![ToolDef::new(
+        "strata_configure_model",
+        "Configure an inference model endpoint for intelligent search. \
+         When configured, search() transparently expands queries using the model \
+         for better recall. Accepts any OpenAI-compatible endpoint (Ollama, vLLM, OpenAI).",
+        schema!(object {
+            required: { "endpoint": string, "model": string },
+            optional: { "api_key": string, "timeout_ms": integer }
+        }),
+    )]
+}
+
+/// Dispatch a configuration tool call.
+pub fn dispatch(
+    session: &mut McpSession,
+    name: &str,
+    args: Map<String, JsonValue>,
+) -> Result<JsonValue> {
+    match name {
+        "strata_configure_model" => {
+            let endpoint = get_string_arg(&args, "endpoint")?;
+            let model = get_string_arg(&args, "model")?;
+            let api_key = get_optional_string(&args, "api_key");
+            let timeout_ms = get_optional_u64(&args, "timeout_ms");
+
+            let cmd = Command::ConfigureModel {
+                endpoint,
+                model,
+                api_key,
+                timeout_ms,
+            };
+            session.execute(cmd)?;
+            Ok(serde_json::json!({ "status": "ok" }))
+        }
+
+        _ => Err(McpError::UnknownTool(name.to_string())),
+    }
+}

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -4,6 +4,7 @@
 
 pub mod branch;
 pub mod bundle;
+pub mod config;
 pub mod database;
 pub mod event;
 pub mod json;
@@ -67,6 +68,7 @@ impl ToolRegistry {
         tools.extend(search::tools());
         tools.extend(bundle::tools());
         tools.extend(retention::tools());
+        tools.extend(config::tools());
 
         Self { tools }
     }
@@ -104,6 +106,8 @@ impl ToolRegistry {
             txn::dispatch(session, name, args)
         } else if name.starts_with("strata_search") {
             search::dispatch(session, name, args)
+        } else if name.starts_with("strata_configure_") {
+            config::dispatch(session, name, args)
         } else if name.starts_with("strata_bundle_") {
             bundle::dispatch(session, name, args)
         } else if name.starts_with("strata_retention_") {


### PR DESCRIPTION
## Summary
- Adds `strata_configure_model` tool to the MCP server with `endpoint`, `model`, `api_key`, and `timeout_ms` parameters
- Registers the new tool in the tool registry and dispatcher
- Enables AI assistants to configure intelligent search via the MCP protocol

## Dependencies
- Requires [strata-core PR #1119](https://github.com/stratadb-labs/strata-core/pull/1119) to be merged first (adds `Command::ConfigureModel` to the engine)

## Test plan
- [ ] Merge strata-core PR #1119 first
- [ ] Verify `cargo build` succeeds against updated `main` branch
- [ ] Test calling `strata_configure_model` tool via MCP protocol
- [ ] Verify `strata_search` transparently uses expansion when model configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)